### PR TITLE
ドキュメント内のDockerコマンドを修正

### DIFF
--- a/docs/pages/unidic-dicgen.md
+++ b/docs/pages/unidic-dicgen.md
@@ -55,7 +55,7 @@ docker run --rm -v $(pwd):/root/workspace tdmelodic:latest \
     tdmelodic-convert \
     -m unidic \
     --input neologd_modified.csv \
-    --output ${WORKDIR}/tdmelodic_original.csv
+    --output tdmelodic_original.csv
 cp ${WORKDIR}/tdmelodic_original.csv ${WORKDIR}/tdmelodic.csv # backup
 ```
 


### PR DESCRIPTION
「UniDic ユーザー向け辞書生成」の章のアクセント辞書生成のためのコマンドがそのままでは動かないので修正しました。

合わせてどこか他に修正が必要であればご教授ください。
